### PR TITLE
OutputPath is not really optional

### DIFF
--- a/src/Pslayers.php
+++ b/src/Pslayers.php
@@ -85,7 +85,7 @@ class Pslayers
             $this->masterCanvas->compositeImage($layer->render(), $layer->composite, $layer->positionX, $layer->positionY);
         }
 
-        if ($this->config->outputPath !== null) {
+        if (isset($this->config->outputPath) && $this->config->outputPath !== null) {
             $this->masterCanvas->writeImage($this->config->outputPath);
         }
 

--- a/tests/Pslayers/PslayersTest.php
+++ b/tests/Pslayers/PslayersTest.php
@@ -295,6 +295,11 @@ class PslayersTest extends \PHPUnit_Framework_TestCase
 
         $instance->addLayer($backgroundLayer, 0);
         $instance->addLayer($gradientLayer, 1);
-        $instance->render();
+        $img = $instance->render();
+
+        $this->assertInstanceOf(Pslayers::class, $instance);
+        $this->assertNotEmpty($instance->layers);
+        $this->assertInstanceOf(LayerCollection::class, $instance->layers);
+        $this->assertInstanceOf(Imagick::class, $img);
     }
 }

--- a/tests/Pslayers/PslayersTest.php
+++ b/tests/Pslayers/PslayersTest.php
@@ -251,4 +251,50 @@ class PslayersTest extends \PHPUnit_Framework_TestCase
 
         // $instance->render();
     }
+
+    //Output path was not really optional
+    public function testOptionalOutputPath()
+    {
+        $width = 830;
+        $height = 360;
+
+        $config = [
+            'id' => 11,
+            'width' => $width,
+            'height' => $height,
+        ];
+
+        $instance = new Pslayers($config);
+
+        // background layer
+        $backgroundLayer = new SolidLayer([
+            'id' => 'master-layer-solid-base',
+            'width' => $width,
+            'height' => $height,
+            'opacity' => 1.0,
+            'positionX' => 0,
+            'positionY' => 0,
+            'composite' => Imagick::COMPOSITE_DEFAULT,
+            'colour' => '#0F0',
+        ]);
+
+        $instance->addLayer($backgroundLayer, 0);
+
+        // gradient layer
+        $gradientLayer = new GradientLayer([
+            'id' => 'master-layer-gradient',
+            'width' => $width,
+            'height' => $height / 2,
+            'opacity' => 0.9,
+            'positionX' => 0,
+            'positionY' => 0,
+            'composite' => Imagick::COMPOSITE_OVER,
+            'startColour' => '#F00',
+            'endColour' => 'transparent',
+        ]);
+
+        $instance->addLayer($backgroundLayer, 0);
+        $instance->addLayer($gradientLayer, 1);
+        $instance->render();
+    }
 }

--- a/tests/Pslayers/PslayersTest.php
+++ b/tests/Pslayers/PslayersTest.php
@@ -301,5 +301,8 @@ class PslayersTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($instance->layers);
         $this->assertInstanceOf(LayerCollection::class, $instance->layers);
         $this->assertInstanceOf(Imagick::class, $img);
+        $this->assertEquals($width, $img->getImageWidth());
+        $this->assertEquals($height, $img->getImageHeight());
+        $this->assertEquals('png32', $img->getImageFormat());
     }
 }


### PR DESCRIPTION
## Issue
Sometimes you may want to generate images in memory, without the images being saved to an output file. Whenever you don't supply an $outputPath it errors saying `Undefined property: DarrynTen\Pslayers\Config\Config::$outputPath
`, even though this option is optional. This is because it checks the property without fist checking if it is null.

## How I fixed it
I first checked if the $outputpath is set, then check if it is null. I also added tests that were failing before, but now pass as a result of this change.

@darrynten 